### PR TITLE
Fix integration with resource preloader.

### DIFF
--- a/openfl/_internal/renderer/dom/DOMBitmap.hx
+++ b/openfl/_internal/renderer/dom/DOMBitmap.hx
@@ -122,6 +122,7 @@ class DOMBitmap {
 		if (bitmap.__image == null) {
 			
 			bitmap.__image = cast Browser.document.createElement ("img");
+			bitmap.__image.crossOrigin = "Anonymous";
 			bitmap.__image.src = bitmap.bitmapData.image.buffer.__srcImage.src;
 			DOMRenderer.initializeElement (bitmap, bitmap.__image, renderSession);
 			


### PR DESCRIPTION
Fixes integration with resource preloader. 

Without matching resource loader code by setting bitmap.__image.crossOrigin in renderImage to "Anonymous" that image gonna be always fetched and not taken from cache.